### PR TITLE
timeToHide settings/options property updated

### DIFF
--- a/fakeLoader.js
+++ b/fakeLoader.js
@@ -86,9 +86,11 @@
         });
 
         //Time to hide fakeLoader
-        setTimeout(function(){
-            $(el).fadeOut();
-        }, settings.timeToHide);
+        if (settings.timeToHide !== false) {
+            setTimeout(function(){
+                $(el).fadeOut();
+            }, settings.timeToHide);
+        }
 
         //Return Styles 
         return this.css({


### PR DESCRIPTION
- added the possibility of putting the 'false' value to options.timeToHide. That resulted in having the possibility for a user to not specify the exact milliseconds value to timeToHide and therefore getting the infinite spinner. Useful in situations where the user needs to wait longer time for some content to be ready in the background before programatically fading out the spinner.
- monkey-patching or adding the maximum 32 bit int to setTimeout seemed like bad choices.
- consider adding a package.json
- still needs a minified version from you if accepted
